### PR TITLE
Scoped launch file inclusion, and some cleaning up of python launch files

### DIFF
--- a/hooks/gateway_description.dsv.in
+++ b/hooks/gateway_description.dsv.in
@@ -1,1 +1,1 @@
-prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/@PROJECT_NAME@/models

--- a/launch/gateway_gz.launch.py
+++ b/launch/gateway_gz.launch.py
@@ -1,79 +1,73 @@
-from launch import LaunchDescription
-from launch.actions import SetEnvironmentVariable, IncludeLaunchDescription
-from launch.substitutions import PathJoinSubstitution
-from launch_ros.actions import Node, SetParameter
-from launch_ros.substitutions import FindPackageShare
-from launch.event_handlers import OnProcessExit
+import os
 
 from ament_index_python.packages import get_package_share_directory
-
-import os
-import xacro
+from craftsman_utils.launch.actions import ScopedIncludeLaunchDescription
+from launch import LaunchDescription
+from launch_ros.actions import Node, SetParameter
+from launch_ros.substitutions import FindPackageShare
+from launch.actions import SetEnvironmentVariable
+from launch.substitutions import PathJoinSubstitution
 
 
 def generate_launch_description():
 
-  # Gazebo setup
-  sim_resource_path = os.pathsep.join([
-    os.environ.get("GZ_SIM_RESOURCE_PATH", default=""),
-    os.path.join(get_package_share_directory("gateway_description"), "models" )
-  ])
-  env_gz_sim = SetEnvironmentVariable("GZ_SIM_RESOURCE_PATH", sim_resource_path)
+    # Gazebo setup
+    sim_resource_path = os.pathsep.join(
+        [
+            os.environ.get("GZ_SIM_RESOURCE_PATH", default=""),
+            os.path.join(get_package_share_directory("gateway_description"), "models"),
+        ]
+    )
+    env_gz_sim = SetEnvironmentVariable("GZ_SIM_RESOURCE_PATH", sim_resource_path)
 
-  # World
-  cislunar_sdf = PathJoinSubstitution([
-    FindPackageShare("gateway_description"), "worlds", "cislunar.sdf"
-  ])
+    # World
+    cislunar_sdf = PathJoinSubstitution(
+        [FindPackageShare("gateway_description"), "worlds", "cislunar.sdf"]
+    )
 
-  # Launch gazebo world
-  gz_launch = IncludeLaunchDescription(
-    PathJoinSubstitution([FindPackageShare("ros_gz_sim"), "launch", "gz_sim.launch.py"]),
-    launch_arguments=[
-      ("gz_args", [
-          cislunar_sdf,
-          " -r",
-          " -v 4"
-      ])
-    ]
-  )
+    # Launch gazebo world
+    gz_launch = ScopedIncludeLaunchDescription(
+        package="ros_gz_sim",
+        launch_file="launch/gz_sim.launch.py",
+        launch_arguments={"gz_args": [cislunar_sdf, " -r", " -v 4"]},
+    )
 
-  # Spawn Gateway
-  gateway = IncludeLaunchDescription(
-    PathJoinSubstitution([
-      FindPackageShare("gateway_description"), "launch", "spawn_gateway.launch.py"
-    ])
-  )
+    # Spawn Gateway
+    gateway = ScopedIncludeLaunchDescription(
+        package="gateway_description",
+        launch_file="launch/spawn_gateway.launch.py",
+    )
 
-  # Spawn big arm and its controllers
-  big_arm = IncludeLaunchDescription(
-    PathJoinSubstitution([
-      FindPackageShare("gateway_description"), "launch", "spawn_big_arm.launch.py"
-    ])
-  )
+    # Spawn big arm and its controllers
+    big_arm = ScopedIncludeLaunchDescription(
+        package="gateway_description",
+        launch_file="launch/spawn_big_arm.launch.py",
+    )
 
-  # Spawn little arm and its controllers
-  little_arm = IncludeLaunchDescription(
-    PathJoinSubstitution([
-      FindPackageShare("gateway_description"), "launch", "spawn_little_arm.launch.py"
-    ])
-  )
+    # Spawn little arm and its controllers
+    little_arm = ScopedIncludeLaunchDescription(
+        package="gateway_description",
+        launch_file="launch/spawn_little_arm.launch.py",
+    )
 
-  # Make the /clock topic available in ROS
-  gz_sim_bridge = Node(
-    package="ros_gz_bridge",
-    executable="parameter_bridge",
-    arguments=[
-      "/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock",
-    ],
-    output="screen",
-  )
+    # Make the /clock topic available in ROS
+    gz_sim_bridge = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        arguments=[
+            "/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock",
+        ],
+        output="screen",
+    )
 
-  return LaunchDescription([
-    SetParameter(name="use_sim_time", value=True),
-    env_gz_sim,
-    gz_launch,
-    gateway,
-    big_arm,
-    little_arm,
-    gz_sim_bridge
-  ])
+    return LaunchDescription(
+        [
+            SetParameter(name="use_sim_time", value=True),
+            env_gz_sim,
+            gz_launch,
+            gateway,
+            big_arm,
+            little_arm,
+            gz_sim_bridge,
+        ]
+    )


### PR DESCRIPTION
* Use craftsman_utils' scoped launch include to prevent polluting launch arguments globally
* Cleaning up
    * Removed unused python imports
    * Reduce number of “get_package_share_directory” calls in launch files
    * Auto code formatting using black - default setting + overwriting line length setting to be 100 characters, to follow ROS guidelines.

